### PR TITLE
fix: max_response_output_tokens in session-related events

### DIFF
--- a/client_event.go
+++ b/client_event.go
@@ -50,7 +50,7 @@ type ClientSession struct {
 	// Sampling temperature for the model.
 	Temperature *float32 `json:"temperature,omitempty"`
 	// Maximum number of output tokens for a single assistant response, inclusive of tool calls. Provide an integer between 1 and 4096 to limit output tokens, or "inf" for the maximum available tokens for a given model. Defaults to "inf".
-	MaxOutputTokens IntOrInf `json:"max_output_tokens,omitempty"`
+	MaxOutputTokens IntOrInf `json:"max_response_output_tokens,omitempty"`
 }
 
 // SessionUpdateEvent is the event for session update.

--- a/client_event_test.go
+++ b/client_event_test.go
@@ -107,7 +107,7 @@ func TestSessionUpdateEvent(t *testing.T) {
 					}
 			},
 			"temperature": 0.5,
-			"max_output_tokens": 100
+			"max_response_output_tokens": 100
 	},
 	"type": "session.update"
 }`
@@ -199,7 +199,7 @@ func TestSessionUpdateEventSimple(t *testing.T) {
 			"output_audio_format": "g711-ulaw",
 			"turn_detection": null,
 			"temperature": 0.5,
-			"max_output_tokens": 100
+			"max_response_output_tokens": 100
 	},
 	"type": "session.update"
 }`

--- a/examples/voice/voice-voice/main.go
+++ b/examples/voice/voice-voice/main.go
@@ -96,7 +96,7 @@ func main() {
 			for data := range datas {
 				fulldata = append(fulldata, data...)
 			}
-			os.WriteFile(fmt.Sprintf("%s.pcm", event.(openairt.ResponseAudioDoneEvent).EventID), fulldata, 0o644)
+			// os.WriteFile(fmt.Sprintf("%s.pcm", event.(openairt.ResponseAudioDoneEvent).EventID), fulldata, 0o644)
 			streamer := pcm.NewPCMStream(
 				fulldata,
 				beep.Format{
@@ -136,7 +136,8 @@ func main() {
 			InputAudioTranscription: &openairt.InputAudioTranscription{
 				Model: openai.Whisper1,
 			},
-			TurnDetection: nil,
+			TurnDetection:   nil,
+			MaxOutputTokens: 4000,
 		},
 	})
 	if err != nil {
@@ -186,8 +187,7 @@ Loop:
 			conn.SendMessage(ctx, openairt.InputAudioBufferCommitEvent{})
 			conn.SendMessage(ctx, openairt.ResponseCreateEvent{
 				Response: openairt.ResponseCreateParams{
-					Modalities:      []openairt.Modality{openairt.ModalityText, openairt.ModalityAudio},
-					MaxOutputTokens: 4000,
+					Modalities: []openairt.Modality{openairt.ModalityText, openairt.ModalityAudio},
 				},
 			})
 		}

--- a/server_event_test.go
+++ b/server_event_test.go
@@ -102,7 +102,7 @@ func TestSessionCreatedEvent(t *testing.T) {
         "tools": [],
         "tool_choice": "auto",
         "temperature": 0.8,
-        "max_output_tokens": null
+        "max_response_output_tokens": null
     }
 }`
 	temperature := float32(0.8)
@@ -163,7 +163,7 @@ func TestSessionUpdatedEvent(t *testing.T) {
         "tools": [],
         "tool_choice": "none",
         "temperature": 0.7,
-        "max_output_tokens": 200
+        "max_response_output_tokens": 200
     }
 }`
 	temperature := float32(0.7)
@@ -219,7 +219,7 @@ func TestSessionUpdatedEvent(t *testing.T) {
 			"tools": [],
 			"tool_choice": "none",
 			"temperature": 0.7,
-			"max_output_tokens": "inf"
+			"max_response_output_tokens": "inf"
 		}
 	}`
 	expected.Session.MaxOutputTokens = openairt.Inf

--- a/types.go
+++ b/types.go
@@ -253,7 +253,7 @@ type ServerSession struct {
 	// Sampling temperature.
 	Temperature *float32 `json:"temperature,omitempty"`
 	// Maximum number of output tokens.
-	MaxOutputTokens IntOrInf `json:"max_output_tokens,omitempty"`
+	MaxOutputTokens IntOrInf `json:"max_response_output_tokens,omitempty"`
 }
 
 type ItemStatus string


### PR DESCRIPTION
The `session.update` and `session.updated` events use `max_response_output_tokens` instead of `max_output_tokens`

![image](https://github.com/user-attachments/assets/c78a80a7-be9e-4f2d-96db-9dcb41cc2081)

![image](https://github.com/user-attachments/assets/b3b8c3d9-7015-4948-85a7-d427a2a81772)

While `response.create` event uses `max_output_tokens`.

![image](https://github.com/user-attachments/assets/0e2c8b78-e9e8-4d7b-8e3d-db110324e8ce)
