### PR TITLE
feat: update ResponseFunctionCallArgumentsDoneEvent

### DIFF
--- a/server_event.go
+++ b/server_event.go
@@ -358,6 +358,8 @@ type ResponseFunctionCallArgumentsDoneEvent struct {
 	CallID string `json:"call_id"`
 	// The final arguments as a JSON string.
 	Arguments string `json:"arguments"`
+	// The name of the function. Not shown in API reference but present in the actual event.
+	Name string `json:"name"`
 }
 
 // RateLimitsUpdatedEvent is the event for rate limits updated.


### PR DESCRIPTION
The actual response body of ResponseFunctionCallArgumentsDoneEvent contains a string field 'name', which is not in API reference. I suggest add this field because it would otherwise be hard to use function call.

![image](https://github.com/user-attachments/assets/6d71854b-d49b-487f-aaca-0c59d253efc1)
