### PR TITLE
feat: add ResponseID to ResponseCancelEvent

### DIFF
--- a/client_event.go
+++ b/client_event.go
@@ -278,6 +278,8 @@ func (m ResponseCreateEvent) MarshalJSON() ([]byte, error) {
 // See https://platform.openai.com/docs/api-reference/realtime-client-events/response/cancel
 type ResponseCancelEvent struct {
 	EventBase
+	// A specific response ID to cancel - if not provided, will cancel an in-progress response in the default conversation.
+	ResponseID string `json:"response_id"`
 }
 
 func (m ResponseCancelEvent) ClientEventType() ClientEventType {

--- a/client_event_test.go
+++ b/client_event_test.go
@@ -397,15 +397,17 @@ func TestResponseCreateEvent(t *testing.T) {
 }
 
 func TestResponseCancelEvent(t *testing.T) {
-	message := openairt.ResponseCancelEvent{}
+	message := openairt.ResponseCancelEvent{
+		ResponseID: "test-response-id",
+	}
 	data, err := json.Marshal(message)
 	require.NoError(t, err)
-	expected := `{"type":"response.cancel"}`
+	expected := `{"response_id":"test-response-id","type":"response.cancel"}`
 	require.JSONEq(t, expected, string(data))
 
 	message.EventBase.EventID = "test-id"
 	data, err = json.Marshal(message)
 	require.NoError(t, err)
-	expected = `{"event_id":"test-id","type":"response.cancel"}`
+	expected = `{"event_id":"test-id","response_id":"test-response-id","type":"response.cancel"}`
 	require.JSONEq(t, expected, string(data))
 }


### PR DESCRIPTION
optional parameter mentioned in their documentation: https://platform.openai.com/docs/api-reference/realtime-client-events/response/cancel
