### PR TITLE
feat: Transcription only mode

### DIFF
--- a/server_event.go
+++ b/server_event.go
@@ -11,6 +11,7 @@ const (
 	ServerEventTypeError                                            ServerEventType = "error"
 	ServerEventTypeSessionCreated                                   ServerEventType = "session.created"
 	ServerEventTypeSessionUpdated                                   ServerEventType = "session.updated"
+	ServerEventTypeTranscriptionSessionUpdated                      ServerEventType = "transcription_session.updated"
 	ServerEventTypeConversationCreated                              ServerEventType = "conversation.created"
 	ServerEventTypeInputAudioBufferCommitted                        ServerEventType = "input_audio_buffer.committed"
 	ServerEventTypeInputAudioBufferCleared                          ServerEventType = "input_audio_buffer.cleared"
@@ -77,6 +78,15 @@ type SessionCreatedEvent struct {
 // Returned when a session is updated.
 // See https://platform.openai.com/docs/api-reference/realtime-server-events/session/updated
 type SessionUpdatedEvent struct {
+	ServerEventBase
+	// The updated session resource.
+	Session ServerSession `json:"session"`
+}
+
+// TranscriptionSessionUpdatedEvent is the event for session updated.
+// Returned when a session is updated.
+// See https://platform.openai.com/docs/api-reference/realtime-server-events/session/updated
+type TranscriptionSessionUpdatedEvent struct {
 	ServerEventBase
 	// The updated session resource.
 	Session ServerSession `json:"session"`
@@ -375,6 +385,7 @@ type ServerEventInterface interface {
 	ErrorEvent |
 		SessionCreatedEvent |
 		SessionUpdatedEvent |
+		TranscriptionSessionUpdatedEvent |
 		ConversationCreatedEvent |
 		InputAudioBufferCommittedEvent |
 		InputAudioBufferClearedEvent |
@@ -427,6 +438,8 @@ func UnmarshalServerEvent(data []byte) (ServerEvent, error) { //nolint:funlen,cy
 		return unmarshalServerEvent[SessionCreatedEvent](data)
 	case ServerEventTypeSessionUpdated:
 		return unmarshalServerEvent[SessionUpdatedEvent](data)
+	case ServerEventTypeTranscriptionSessionUpdated:
+		return unmarshalServerEvent[TranscriptionSessionUpdatedEvent](data)
 	case ServerEventTypeConversationCreated:
 		return unmarshalServerEvent[ConversationCreatedEvent](data)
 	case ServerEventTypeInputAudioBufferCommitted:

--- a/types.go
+++ b/types.go
@@ -123,7 +123,11 @@ const (
 
 type InputAudioTranscription struct {
 	// The model used for transcription.
-	Model string `json:"model"`
+	Model    string `json:"model"`
+	// The language of the input audio. Supplying the input language in ISO-639-1 (e.g. en) format will improve accuracy and latency.
+	Language string `json:"language,omitempty"`
+	// An optional text to guide the model's style or continue a previous audio segment. For whisper-1, the prompt is a list of keywords. For gpt-4o-transcribe models, the prompt is a free text string, for example "expect words related to technology".
+	Prompt   string `json:"prompt,omitempty"`
 }
 
 type Tool struct {


### PR DESCRIPTION
This adds the necessary bits for a client to connect in transcription only mode with the caveat that I only tested it against my own implementation in LocalAI (https://github.com/mudler/LocalAI/pull/5392) rather than OpenAI.

BTW I also vendored this library into LocalAI to help with the realtime support. I guessed that because this is primarily a client library, it would probably be best to vendor it, but we'll see.