### PR TITLE
fix: Add transcription session created event

### DIFF
--- a/server_event.go
+++ b/server_event.go
@@ -11,6 +11,7 @@ const (
 	ServerEventTypeError                                            ServerEventType = "error"
 	ServerEventTypeSessionCreated                                   ServerEventType = "session.created"
 	ServerEventTypeSessionUpdated                                   ServerEventType = "session.updated"
+	ServerEventTypeTranscriptionSessionCreated                      ServerEventType = "transcription_session.created"
 	ServerEventTypeTranscriptionSessionUpdated                      ServerEventType = "transcription_session.updated"
 	ServerEventTypeConversationCreated                              ServerEventType = "conversation.created"
 	ServerEventTypeInputAudioBufferCommitted                        ServerEventType = "input_audio_buffer.committed"
@@ -81,6 +82,15 @@ type SessionCreatedEvent struct {
 type SessionUpdatedEvent struct {
 	ServerEventBase
 	// The updated session resource.
+	Session ServerSession `json:"session"`
+}
+
+// TranscriptionSessionCreatedEvent is the event for session created.
+// Returned when a transcription session is created.
+// See https://platform.openai.com/docs/api-reference/realtime-server-events/session/created
+type TranscriptionSessionCreatedEvent struct {
+	ServerEventBase
+	// The transcription session resource.
 	Session ServerSession `json:"session"`
 }
 
@@ -393,6 +403,7 @@ type ServerEventInterface interface {
 	ErrorEvent |
 		SessionCreatedEvent |
 		SessionUpdatedEvent |
+		TranscriptionSessionCreatedEvent |
 		TranscriptionSessionUpdatedEvent |
 		ConversationCreatedEvent |
 		InputAudioBufferCommittedEvent |
@@ -447,6 +458,8 @@ func UnmarshalServerEvent(data []byte) (ServerEvent, error) { //nolint:funlen,cy
 		return unmarshalServerEvent[SessionCreatedEvent](data)
 	case ServerEventTypeSessionUpdated:
 		return unmarshalServerEvent[SessionUpdatedEvent](data)
+	case ServerEventTypeTranscriptionSessionCreated:
+		return unmarshalServerEvent[TranscriptionSessionCreatedEvent](data)
 	case ServerEventTypeTranscriptionSessionUpdated:
 		return unmarshalServerEvent[TranscriptionSessionUpdatedEvent](data)
 	case ServerEventTypeConversationCreated:


### PR DESCRIPTION
OpenAI first sends a transcription session created event when specifying
the transcription intent, but we only handle transcription session updated.

Needed to fix this: https://github.com/richiejp/VoxInput/issues/22
