### PR TITLE
fix: Allow function parameters to be empty

### DIFF
--- a/types.go
+++ b/types.go
@@ -175,8 +175,8 @@ type ToolFunction struct {
 	// The description of the function, including guidance on when and how to call it, and guidance about what to tell the user when calling (if anything).
 	Description string `json:"description"`
 
-	// The type of the tool, i.e. function.
-	Parameters any `json:"parameters"`
+	// The parameters of the function expressed as jsonschema
+	Parameters any `json:"parameters,omitempty"`
 }
 
 func (t ToolFunction) ToolType() ToolType {


### PR DESCRIPTION
In fact all the fields are marked as optional in the spec, but only parameters makes sense to be empty IMO.